### PR TITLE
Fix: include_dirs

### DIFF
--- a/game.project
+++ b/game.project
@@ -20,3 +20,5 @@ allow_dynamic_transforms = 0
 [sprite]
 max_count = 1024
 
+[library]
+include_dirs = acidrain


### PR DESCRIPTION
Adds [include_dirs](https://defold.com/manuals/libraries/#setting-up-library-sharing) project value to allow this repo to be used as a library in Defold.

Users can then require it using: `local acidrain = require('acidrain.acidrain')`